### PR TITLE
Fix aexpect imports

### DIFF
--- a/spice/tests/rv_build_install.py
+++ b/spice/tests/rv_build_install.py
@@ -9,8 +9,8 @@ import logging
 import os
 import time
 import re
+from aexpect import ShellCmdError
 from autotest.client.shared import error
-from virttest.aexpect import ShellCmdError
 from virttest import utils_misc, utils_spice
 
 

--- a/spice/tests/rv_copyandpaste.py
+++ b/spice/tests/rv_copyandpaste.py
@@ -8,8 +8,9 @@ Requires: rv_setup for windows guest tests
 
 """
 import logging, os, time
+import aexpect
 from autotest.client.shared import error
-from virttest import utils_misc, utils_spice, aexpect
+from virttest import utils_misc, utils_spice
 
 
 def wait_timeout(timeout=10):

--- a/spice/tests/rv_fullscreen.py
+++ b/spice/tests/rv_fullscreen.py
@@ -8,8 +8,8 @@ Requires: connected binaries remote-viewer, Xorg, gnome session
 
 """
 import logging
+from aexpect import ShellCmdError
 from autotest.client.shared import error
-from virttest.aexpect import ShellCmdError
 
 
 def run_rv_fullscreen(test, params, env):

--- a/spice/tests/rv_gui.py
+++ b/spice/tests/rv_gui.py
@@ -10,7 +10,7 @@ and have to have both client & remote viewer window available.
 from virttest.virt_vm import VMDeadError
 import os, logging
 from autotest.client.shared import error
-from virttest.aexpect import ShellCmdError
+from aexpect import ShellCmdError
 from virttest import utils_net, utils_spice
 from time import sleep
 

--- a/spice/tests/rv_input.py
+++ b/spice/tests/rv_input.py
@@ -10,9 +10,9 @@ Requires: Two VMs - client and guest and remote-viewer session
 
 import logging
 import os
+from aexpect import ShellCmdError
 from autotest.client.shared import error
-from virttest.aexpect import ShellCmdError
-from virttest import utils_misc, utils_spice, aexpect
+from virttest import utils_misc, utils_spice
 
 
 def install_pygtk(guest_session, params):
@@ -284,7 +284,7 @@ def run_rv_input(test, params, env):
     # Verify that gnome is now running on the guest
     try:
         guest_session.cmd("ps aux | grep -v grep | grep gnome-session")
-    except aexpect.ShellCmdError:
+    except ShellCmdError:
         raise error.TestWarn("gnome-session was probably not corretly started")
 
     guest_session.cmd("export DISPLAY=:0.0")

--- a/spice/tests/rv_setup.py
+++ b/spice/tests/rv_setup.py
@@ -11,8 +11,9 @@ Requires: the client and guest VMs to be setup.
 """
 
 import logging, os
+import aexpect
 from os import system, getcwd, chdir
-from virttest import utils_misc, utils_spice, aexpect
+from virttest import utils_misc, utils_spice
 
 def install_rpm(session, name, rpm):
     """

--- a/spice/tests/rv_smartcard.py
+++ b/spice/tests/rv_smartcard.py
@@ -8,7 +8,7 @@ options to handle smartcards.
 
 """
 import logging
-from virttest import aexpect
+import aexpect
 from autotest.client.shared import error
 
 

--- a/spice/tests/rv_vmshutdown.py
+++ b/spice/tests/rv_vmshutdown.py
@@ -5,9 +5,9 @@ Requires: connected binaries remote-viewer, Xorg, gnome session
 
 """
 import logging
+from aexpect import ShellCmdError
 from virttest.virt_vm import VMDeadError
 from autotest.client.shared import error
-from virttest.aexpect import ShellCmdError
 from virttest import utils_spice
 from virttest import utils_misc
 from virttest import utils_net

--- a/spice/tests/smartcard_setup.py
+++ b/spice/tests/smartcard_setup.py
@@ -9,7 +9,8 @@ to be generated.
 
 """
 import logging
-from virttest import utils_misc, utils_spice, aexpect
+import aexpect
+from virttest import utils_misc, utils_spice
 from autotest.client.shared import error
 
 


### PR DESCRIPTION
Aexpect is not part of avocado but standalone project.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>