### PR TITLE
Ignore missing packages in RHEL-7-spice.ks

### DIFF
--- a/spice/unattended/RHEL-7-spice.ks
+++ b/spice/unattended/RHEL-7-spice.ks
@@ -50,7 +50,7 @@ firstboot --disable
 #
 # Packages.
 #
-%packages --default
+%packages --default --ignoremissing
 @smart-card
 spice-vdagent
 virt-viewer


### PR DESCRIPTION
Not all packages are available on all architectures (ppc for instance), let's avoid hangs and proceed without the missing packages.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>