### PR TITLE
New testcases: mostly spice_ssl listen

### DIFF
--- a/spice/cfg/tests-variants.cfg
+++ b/spice/cfg/tests-variants.cfg
@@ -474,8 +474,57 @@ variants:
                     error_msg = "binding socket to :${spice_port} failed"
                     start_vm = no
 
+                - 172897:
+                    variants:
+                        - req__ss__ssl__on:
+                            spice_tls_port = 3001
+                            spice_secure_channels =
+                            spice_port = no
+
+                - 172898:
+                    variants:
+                        - req__ss__ssl__on:
+                            spice_tls_port = 3001.1
+                            spice_secure_channels =
+                            spice_port = no
+                    error_msg = "Parameter 'tls-port' expects a number"
+                    start_vm = no
+
+                - 172900:
+                    variants:
+                        - req__ss__ssl__on:
+                            spice_tls_port = -3001
+                            spice_secure_channels =
+                            spice_port = no
+                    error_msg = "spice tls-port is out of range"
+                    start_vm = no
+
+                - 172905:
+                    variants:
+                        - req__ss__ssl__on:
+                            spice_tls_port = blabla
+                            spice_secure_channels =
+                            spice_port = no
+                    error_msg = "Parameter 'tls-port' expects a number"
+                    start_vm = no
+
+                - 172906:
+                    variants:
+                        - req__ss__ssl__on:
+                            spice_tls_port = 123456
+                            spice_secure_channels =
+                            spice_port = no
+                    error_msg = "spice tls-port is out of range"
+                    start_vm = no
+
                 - 172909:
                     spice_addr = 127.0.0.1
+
+                - 172912:
+                    spice_addr = 1.1.1.1
+                    spice_port = 3000
+                    error_msg = "binding socket to ${spice_addr}:${spice_port} failed"
+                    start_vm = no
 
                 - 172913:
                     spice_addr = 0.0.0.0
@@ -515,20 +564,19 @@ variants:
                     error_msg = "spice port is out of range"
                     start_vm = no
 
-                - 172927: # TODO: probably qemu_vm.py modification needed
-                    spice_port = ''
+                - 172927: #BZ#1417864
+                    spice_port = ''''
                     error_msg = "neither port nor tls-port specified for spice"
                     start_vm = no
 
                 - 172929: # TODO
                     spice_port = 40
                     error_msg = "binding to socket ${spice_port} failed"
-                    admin = no
+                    user_runas = test
                     start_vm = no
 
                 - 172930:
                     spice_port = 40
-                    admin = yes
 
                 - 172933:
                     spice_port = blabla

--- a/spice/lib/vm_actions_linux.py
+++ b/spice/lib/vm_actions_linux.py
@@ -116,7 +116,9 @@ def verify_vdagent(vmi):
 def verify_listen(vmi):
     """Verify SPICE guest is listening on specific sockets
     """
-    s_port = vmi.kvm.spice_port
+    s_port = vmi.kvm.spice_tls_port
+    if not s_port:
+        s_port = vmi.kvm.spice_port
     s_addr = vmi.kvm.spice_addr
     if not s_addr:
         s_addr = '0.0.0.0'


### PR DESCRIPTION
Signed-off-by: Radek Duda <rduda@redhat.com>

`spice_port = no` introduces https://github.com/avocado-framework/avocado-vt/pull/960