### PR TITLE
Update IP of proxy server

### DIFF
--- a/spice/cfg/tests-variants.cfg
+++ b/spice/cfg/tests-variants.cfg
@@ -188,7 +188,7 @@ variants:
                 - 527185:
                     # As for Feb 2017 RHEL 7 qemu-kvm doesn't listen on IPv6.
                     # Only for qemu-kvm-rhev testing.
-                    spice_proxy = [${http_proxy_ipv6}]:80
+                    spice_proxy = [${http_proxy_ipv6}]
                     include join.cfg
 
                 - 546907:

--- a/spice/cfg/tests.cfg
+++ b/spice/cfg/tests.cfg
@@ -41,8 +41,8 @@ no build_install
 include run.cfg
 
 # General environment parameters.
-http_proxy_ip = 10.34.73.1
-http_proxy_ipv6 = 2620:52:0:2249:21a:4aff:fe01:46a3
+http_proxy_ip = 192.168.215.1
+http_proxy_ipv6 = fddd:c:c:c::1
 http_proxy_port = 3128
 http_proxy_fqdn = proxy.spice.brq.redhat.com
 


### PR DESCRIPTION
Update IP address of proxy server. Now we have proxy on host (spice_br bridge) (see https://gitlab.cee.redhat.com/spiceqe/spice-qe-tests/blob/master/runtest.sh#L232)

Signed-off-by: Radek Duda <rduda@redhat.com>