### PR TITLE
Use spice_br IP for squid proxy

### DIFF
--- a/spice/lib/utils.py
+++ b/spice/lib/utils.py
@@ -388,11 +388,7 @@ def get_host_ip(test):
     if not ip_ver:
         ip_ver = "ipv4"
     try:
-        if test.cfg.spice_proxy:
-            def_gate = utils_net.get_host_default_gateway(iface_name=True)
-            ip = utils_net.get_ip_address_by_interface(def_gate, ip_ver)
-        else:
-            ip = utils_net.get_host_ip_address(test.cfg, ip_ver)
+        ip = utils_net.get_host_ip_address(test.cfg, ip_ver)
     except utils_net.NetError:
         ips = utils_net.get_all_ips()
         ip = ips[0]


### PR DESCRIPTION
Removed since we are using `spice_br` as `squid` proxy interface now. (see https://github.com/spiceqa/tp-spice/commit/b4d5e3c763859d19c7584cfbf22e963db1706dee)


Signed-off-by: Radek Duda <rduda@redhat.com>