### PR TITLE
Proxy fqdn correction

### DIFF
--- a/spice/cfg/tests-variants.cfg
+++ b/spice/cfg/tests-variants.cfg
@@ -192,7 +192,7 @@ variants:
                     include join.cfg
 
                 - 546907:
-                    spice_proxy = ${http_proxy_fqdn}
+                    spice_proxy = ${http_proxy_fqdn}:${http_proxy_port}
                     include join.cfg
 
         - rv_copypaste:

--- a/spice/cfg/tests.cfg
+++ b/spice/cfg/tests.cfg
@@ -44,7 +44,8 @@ include run.cfg
 http_proxy_ip = 192.168.215.1
 http_proxy_ipv6 = fddd:c:c:c::1
 http_proxy_port = 3128
-http_proxy_fqdn = proxy.spice.brq.redhat.com
+# This FQDN is assigned to spice_br virual bridge (see /etc/hosts).
+http_proxy_fqdn = proxy.spice_br.com
 
 variants:
     - role-guest:


### PR DESCRIPTION
Use fqdn on spice_br interface.
there is yet missing part `echo '$ip_spice_br $fqdn_spice_br' >> /etc/hosts`.

Signed-off-by: Radek Duda <rduda@redhat.com>