### PR TITLE
rv*.py: Fix Display*.kmap assignment

### DIFF
--- a/spice/client-tests/rv6.py
+++ b/spice/client-tests/rv6.py
@@ -493,7 +493,8 @@ class DisplayAccessKey(Display):
     def __init__(self, app, num, kmap=None):
         super(DisplayAccessKey, self).__init__(app, num)
         if not kmap:
-            self.kmap = {}
+            kmap = {}
+        self.kmap = {}
         self.kmap.update(DisplayAccessKey.def_key_mapping)
         self.kmap.update(kmap)
 
@@ -577,7 +578,8 @@ class DisplayHotKey(Display):
     def __init__(self, app, num, kmap=None):
         super(DisplayHotKey, self).__init__(app, num)
         if not kmap:
-            self.kmap = {}
+            kmap = {}
+        self.kmap = {}
         self.kmap.update(DisplayHotKey.def_key_mapping)
         self.kmap.update(kmap)
 
@@ -615,7 +617,8 @@ class DisplayWMKey(Display):
     def __init__(self, app, num, kmap=None):
         super(DisplayWMKey, self).__init__(app, num)
         if not kmap:
-            self.kmap = {}
+            kmap = {}
+        self.kmap = {}
         self.kmap.update(DisplayWMKey.def_key_mapping)
         self.kmap.update(kmap)
 

--- a/spice/client-tests/rv7.py
+++ b/spice/client-tests/rv7.py
@@ -465,7 +465,8 @@ class DisplayAccessKey(Display):
     def __init__(self, app, num, kmap=None):
         super(DisplayAccessKey, self).__init__(app, num)
         if not kmap:
-            self.kmap = {}
+            kmap = {}
+        self.kmap = {}
         self.kmap.update(DisplayAccessKey.def_key_mapping)
         self.kmap.update(kmap)
 
@@ -551,7 +552,8 @@ class DisplayHotKey(Display):
     def __init__(self, app, num, kmap=None):
         super(DisplayHotKey, self).__init__(app, num)
         if not kmap:
-            self.kmap = {}
+            kmap = {}
+        self.kmap = {}
         self.kmap.update(DisplayHotKey.def_key_mapping)
         self.kmap.update(kmap)
 
@@ -591,7 +593,8 @@ class DisplayWMKey(Display):
     def __init__(self, app, num, kmap=None):
         super(DisplayWMKey, self).__init__(app, num)
         if not kmap:
-            self.kmap = {}
+            kmap = {}
+        self.kmap = {}
         self.kmap.update(DisplayWMKey.def_key_mapping)
         self.kmap.update(kmap)
 


### PR DESCRIPTION
`kmap.update(kmap)` cannot be done if `kmap == None`. `self.kmap` must be set to `{}` always.

Signed-off-by: Radek Duda <rduda@redhat.com>