### PR TITLE
rv7.py: rename "Name:" label

### DIFF
--- a/spice/client-tests/rv7.py
+++ b/spice/client-tests/rv7.py
@@ -320,7 +320,7 @@ class DisplayMouse(Display):
         n = self.dsp.menu('File').menuItem('Screenshot')
         do_click(n)
         file_chooser = self.app.child(roleName='file chooser')
-        file_chooser.childLabelled('Name:').text = filename
+        file_chooser.childLabelled('Name').text = filename
         n = file_chooser.button('Save')
         do_click(n)
         if self.app.isChild(roleName='alert', name='Question'):
@@ -529,7 +529,7 @@ class DisplayAccessKey(Display):
     def screenshot(self, filename):
         self.menu('File', ['File|Screenshot'])
         file_chooser = self.app.child(roleName='file chooser')
-        file_chooser.childLabelled('Name:').text = filename
+        file_chooser.childLabelled('Name').text = filename
         n = file_chooser.button('Save')
         do_click(n)
         if self.app.isChild(roleName='alert', name='Question'):


### PR DESCRIPTION
Due to change in Gnome desktop label..

Signed-off-by: Radek Duda <rduda@redhat.com>